### PR TITLE
Fix heading pluralization in test API doc

### DIFF
--- a/server/src/main/kotlin/dk/example/geoapp/docs/test_api.http
+++ b/server/src/main/kotlin/dk/example/geoapp/docs/test_api.http
@@ -19,7 +19,7 @@ Content-Type: application/json
 {"types":["1012","3012"]}
 
 
-### Fetch *all* facility
+### Fetch *all* facilities
 POST {{baseUrl}}{{geoItems}}
 Accept: application/json
 Content-Type: application/json


### PR DESCRIPTION
## Summary
- update wording of the "Fetch all facilities" heading in the test HTTP file

## Testing
- `./gradlew test` *(fails: JVM main run task conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684dd2222b788321a3812696a75ae76b