### PR TITLE
Fix docker build by adding missing scheduler

### DIFF
--- a/server/src/main/kotlin/dk/example/geoapp/Application.kt
+++ b/server/src/main/kotlin/dk/example/geoapp/Application.kt
@@ -61,7 +61,7 @@ fun Application.module() {
     )
 
     // Start daily refresh job
-    startDailyRefreshJob(refreshGeoItems)
+    startDailyRefreshJob { refreshGeoItems() }
 
     // Kick-off an *immediate* geo items refresh at start-up
     launch { refreshGeoItems() }

--- a/server/src/main/kotlin/dk/example/geoapp/infrastructure/scheduler/Scheduler.kt
+++ b/server/src/main/kotlin/dk/example/geoapp/infrastructure/scheduler/Scheduler.kt
@@ -1,0 +1,21 @@
+package dk.example.geoapp.infrastructure.scheduler
+
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Starts a scheduled job that invokes [refreshAction] once every day.
+ */
+fun startDailyRefreshJob(refreshAction: suspend () -> Unit) {
+    val executor = Executors.newSingleThreadScheduledExecutor()
+    executor.scheduleAtFixedRate({
+        runBlocking {
+            try {
+                refreshAction()
+            } catch (_: Throwable) {
+                // Swallow exceptions to keep scheduler alive
+            }
+        }
+    }, 0, 1, TimeUnit.DAYS)
+}


### PR DESCRIPTION
## Summary
- implement `startDailyRefreshJob` helper using a scheduled executor
- invoke `startDailyRefreshJob` with a lambda

## Testing
- `./gradlew :server:compileKotlin --no-daemon --console=plain`
- `./gradlew :server:test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_684dd7bf4a048321952d7158ebf6f514